### PR TITLE
[VE] VECodeGen requires Analysis lib

### DIFF
--- a/lib/Target/VE/LLVMBuild.txt
+++ b/lib/Target/VE/LLVMBuild.txt
@@ -29,6 +29,6 @@ has_asmprinter = 1
 type = Library
 name = VECodeGen
 parent = VE
-required_libraries = AsmPrinter CodeGen Core MC SelectionDAG VEAsmPrinter
+required_libraries = Analysis AsmPrinter CodeGen Core MC SelectionDAG VEAsmPrinter
                      VEDesc VEInfo Support Target
 add_to_library_groups = VE


### PR DESCRIPTION
Analysis libs symbols are required when linking LLVMVECodeGen.so.
This only surfaces in shared lib builds of LLVM (`cmake -DBUILD_SHARED_LIBS=on`).

```
[2/812] Linking CXX shared library lib/libLLVMVECodeGen.so.7svn
FAILED: lib/libLLVMVECodeGen.so.7svn
: && /usr/bin/c++ -fPIC -fPIC -fvisibility-inlines-hidden -Werror=date-time -std=c++1y -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -pedantic -Wno-long-long -Wno-maybe-uninitialized -Wdelete-non-virtual-dtor -Wno-comment -fdiagnostics-color -g  -Wl,-z,defs -Wl,-z,nodelete   -Wl,-rpath-link,/home/simon/source/nec/llvm_build/./lib -shared -Wl,-soname,libLLVMVECodeGen.so.7 -o lib/libLLVMVECodeGen.so.7svn lib/Target/VE/CMakeFiles/LLVMVECodeGen.dir/VEAsmPrinter.cpp.o lib/Target/VE/CMakeFiles/LLVMVECodeGen.dir/VEFrameLowering.cpp.o lib/Target/VE/CMakeFiles/LLVMVECodeGen.dir/VEISelDAGToDAG.cpp.o lib/Target/VE/CMakeFiles/LLVMVECodeGen.dir/VEISelLowering.cpp.o lib/Target/VE/CMakeFiles/LLVMVECodeGen.dir/VEInstrInfo.cpp.o lib/Target/VE/CMakeFiles/LLVMVECodeGen.dir/VEMachineFunctionInfo.cpp.o lib/Target/VE/CMakeFiles/LLVMVECodeGen.dir/VEMCInstLower.cpp.o lib/Target/VE/CMakeFiles/LLVMVECodeGen.dir/VERegisterInfo.cpp.o lib/Target/VE/CMakeFiles/LLVMVECodeGen.dir/VESubtarget.cpp.o lib/Target/VE/CMakeFiles/LLVMVECodeGen.dir/VETargetMachine.cpp.o  -Wl,-rpath,"\$ORIGIN/../lib" lib/libLLVMAsmPrinter.so.7svn lib/libLLVMCodeGen.so.7svn lib/libLLVMCore.so.7svn lib/libLLVMMC.so.7svn lib/libLLVMSelectionDAG.so.7svn lib/libLLVMSupport.so.7svn lib/libLLVMTarget.so.7svn lib/libLLVMVEAsmPrinter.so.7svn lib/libLLVMVEDesc.so.7svn lib/libLLVMVEInfo.so.7svn && :
lib/Target/VE/CMakeFiles/LLVMVECodeGen.dir/VETargetMachine.cpp.o: In function `llvm::TargetTransformInfo::Model<llvm::VETTIImpl>::~Model()':
[..]/llvm/include/llvm/Analysis/TargetTransformInfo.h:1182: undefined reference to `llvm::TargetTransformInfo::Concept::~Concept()'
lib/Target/VE/CMakeFiles/LLVMVECodeGen.dir/VETargetMachine.cpp.o: In function `llvm::BasicTTIImplBase<llvm::VETTIImpl>::getUnrollingPreferences(llvm::Loop*, llvm::ScalarEvolution&, llvm::TargetTransformInfo::UnrollingPreferences&)':
[..]/llvm/include/llvm/CodeGen/BasicTTIImpl.h:398: undefined reference to `llvm::LoopBase<llvm::BasicBlock, llvm::Loop>::block_begin() const'
[..]/llvm/include/llvm/CodeGen/BasicTTIImpl.h:398: undefined reference to `llvm::LoopBase<llvm::BasicBlock, llvm::Loop>::block_end() const'
lib/Target/VE/CMakeFiles/LLVMVECodeGen.dir/VETargetMachine.cpp.o: In function `llvm::TargetTransformInfoImplCRTPBase<llvm::VETTIImpl>::getGEPCost(llvm::Type*, llvm::Value const*, llvm::ArrayRef<llvm::Value const*>)':
[..]/llvm/include/llvm/Analysis/TargetTransformInfoImpl.h:729: undefined reference to `llvm::getSplatValue(llvm::Value const*)'
collect2: error: ld returned 1 exit status

```