### PR TITLE
Initial vector instruction support

### DIFF
--- a/lib/Target/VE/VEISelLowering.cpp
+++ b/lib/Target/VE/VEISelLowering.cpp
@@ -1651,12 +1651,12 @@ static SDValue LowerF128Store(SDValue Op, SelectionDAG &DAG) {
 
   SDNode *Hi64 = DAG.getMachineNode(TargetOpcode::EXTRACT_SUBREG,
                                     dl,
-                                    MVT::f64,
+                                    MVT::i64,
                                     StNode->getValue(),
                                     SubRegEven);
   SDNode *Lo64 = DAG.getMachineNode(TargetOpcode::EXTRACT_SUBREG,
                                     dl,
-                                    MVT::f64,
+                                    MVT::i64,
                                     StNode->getValue(),
                                     SubRegOdd);
 

--- a/lib/Target/VE/VEISelLowering.cpp
+++ b/lib/Target/VE/VEISelLowering.cpp
@@ -58,6 +58,313 @@ VETargetLowering::CanLowerReturn(CallingConv::ID CallConv, MachineFunction &MF,
 }
 
 SDValue
+VETargetLowering::LowerBitcast(SDValue Op, SelectionDAG &DAG) const {
+  if (Op.getSimpleValueType() == MVT::v256i64 && Op.getOperand(0).getSimpleValueType() == MVT::v256f64) {
+    LLVM_DEBUG(dbgs() << "Lowering bitcast of similar types.\n");
+    return Op.getOperand(0);
+  } else {
+    return Op;
+  }
+}
+
+SDValue
+VETargetLowering::LowerMGATHER_MSCATTER(SDValue Op, SelectionDAG &DAG) const {
+  LLVM_DEBUG(dbgs() << "Lowering gather or scatter\n");
+  SDLoc dl(Op);
+  //dbgs() << "\nNext Instr:\n";
+  //Op.dumpr(&DAG);
+
+  MaskedGatherScatterSDNode *N = cast<MaskedGatherScatterSDNode>(Op.getNode());
+
+  SDValue Index = N->getIndex();
+  SDValue BasePtr = N->getBasePtr();
+  SDValue Mask = N->getMask();
+  SDValue Chain = N->getChain();
+
+  SDValue PassThru;
+  SDValue Source;
+
+  if (Op.getOpcode() == ISD::MGATHER) {
+    MaskedGatherSDNode *N = cast<MaskedGatherSDNode>(Op.getNode());
+    PassThru = N->getPassThru();
+  } else if (Op.getOpcode() == ISD::MSCATTER) {
+    MaskedScatterSDNode *N = cast<MaskedScatterSDNode>(Op.getNode());
+    Source = N->getValue();
+  } else {
+    return SDValue();
+  }
+
+  MVT IndexVT = Index.getSimpleValueType();
+  //MVT MaskVT = Mask.getSimpleValueType();
+  //MVT BasePtrVT = BasePtr.getSimpleValueType();
+
+  // vindex = vindex + baseptr;
+  SDValue BaseBroadcast = DAG.getNode(VEISD::VEC_BROADCAST, dl, IndexVT, BasePtr);
+  SDValue ScaleBroadcast = DAG.getNode(VEISD::VEC_BROADCAST, dl, IndexVT, N->getScale());
+
+  SDValue index_addr = DAG.getNode(ISD::MUL, dl, IndexVT, {Index, ScaleBroadcast});
+
+  SDValue addresses = DAG.getNode(ISD::ADD, dl, IndexVT, {BaseBroadcast, index_addr});
+
+  // TODO: vmx = svm (mask);
+  //Mask.dumpr(&DAG);
+  if (Mask.getOpcode() != ISD::BUILD_VECTOR || Mask.getNumOperands() != 256) {
+    LLVM_DEBUG(dbgs() << "Cannot handle gathers with complex masks.\n");
+    return SDValue();
+  }
+  for (unsigned i = 0; i < 256; i++) {
+    const SDValue Operand = Mask.getOperand(i);
+    if (Operand.getOpcode() != ISD::Constant) {
+      LLVM_DEBUG(dbgs() << "Cannot handle gather masks with complex elements.\n");
+      return SDValue();
+    }
+    if (Mask.getConstantOperandVal(i) != 1) {
+      LLVM_DEBUG(dbgs() << "Cannot handle gather masks with elements != 1.\n");
+      return SDValue();
+    }
+  }
+
+  if (Op.getOpcode() == ISD::MGATHER) {
+    // vt = vgt (vindex, vmx, cs=0, sx=0, sy=0, sw=0);
+    SDValue load = DAG.getNode(VEISD::VEC_GATHER, dl, Op.getNode()->getVTList(), {Chain, addresses});
+    //load.dumpr(&DAG);
+
+    // TODO: merge (vt, default, vmx);
+    //PassThru.dumpr(&DAG);
+    // We can safely ignore PassThru right now, the mask is guaranteed to be constant 1s.
+
+    return load;
+  } else {
+    SDValue store = DAG.getNode(VEISD::VEC_SCATTER, dl, Op.getNode()->getVTList(), {Chain, Source, addresses});
+    //store.dumpr(&DAG);
+    return store;
+  }
+}
+
+SDValue
+VETargetLowering::LowerMLOAD(SDValue Op, SelectionDAG &DAG) const {
+  LLVM_DEBUG(dbgs() << "Lowering MLOAD\n");
+  LLVM_DEBUG(Op.dumpr(&DAG));
+  SDLoc dl(Op);
+
+  MaskedLoadSDNode *N = cast<MaskedLoadSDNode>(Op.getNode());
+
+  SDValue BasePtr = N->getBasePtr();
+  SDValue Mask = N->getMask();
+  SDValue Chain = N->getChain();
+  SDValue PassThru = N->getPassThru();
+
+  MachinePointerInfo info = N->getPointerInfo();
+
+  if (Mask.getOpcode() != ISD::BUILD_VECTOR || Mask.getNumOperands() != 256) {
+    LLVM_DEBUG(dbgs() << "Cannot handle gathers with complex masks.\n");
+    return SDValue();
+  }
+
+  int firstzero = 256;
+
+  for (unsigned i = 0; i < 256; i++) {
+    const SDValue Operand = Mask.getOperand(i);
+    if (Operand.getOpcode() != ISD::Constant) {
+      LLVM_DEBUG(dbgs() << "Cannot handle load masks with complex elements.\n");
+      return SDValue();
+    }
+    if (Mask.getConstantOperandVal(i) != 1) {
+      if (firstzero == 256)
+        firstzero = i;
+      if (!PassThru.isUndef() && !PassThru.getOperand(i).isUndef()) {
+        LLVM_DEBUG(dbgs() << "Cannot handle passthru.\n");
+        return SDValue();
+      }
+    } else {
+      if (firstzero != 256) {
+        LLVM_DEBUG(dbgs() << "Cannot handle mixed load masks.\n");
+        return SDValue();
+      }
+    }
+  }
+
+  EVT i32 = EVT::getIntegerVT(*DAG.getContext(), 32);
+
+  Chain = DAG.getNode(VEISD::VEC_LVL, dl, MVT::Other, {Chain, DAG.getConstant(firstzero, dl, i32)});
+
+  SDValue load = DAG.getLoad(Op.getSimpleValueType(), dl, Chain, BasePtr, info);
+
+  Chain = DAG.getNode(VEISD::VEC_LVL, dl, MVT::Other, {load.getValue(1), DAG.getConstant(256, dl, i32)});
+
+  SDValue merge = DAG.getMergeValues({load, Chain}, dl);
+  LLVM_DEBUG(dbgs() << "Becomes\n");
+  LLVM_DEBUG(merge.dumpr(&DAG));
+  return merge;
+}
+
+SDValue
+VETargetLowering::LowerBUILD_VECTOR(SDValue Chain, SelectionDAG &DAG) const {
+  LLVM_DEBUG(dbgs() << "Lowering BUILD_VECTOR\n");
+  auto & bvNode = *cast<BuildVectorSDNode>(Chain);
+
+  SDLoc DL(Chain);
+
+// match VEC_BROADCAST
+  bool allUndef = true;
+  unsigned first_def = -1;
+  for (unsigned i = 0; i < bvNode.getNumOperands(); ++i) {
+    if (!bvNode.getOperand(i).isUndef()) {
+      allUndef = false;
+      first_def = i;
+      break;
+    }
+  }
+
+  if (allUndef) {
+    return DAG.getNode(VEISD::VEC_BROADCAST, DL, Chain.getSimpleValueType(),
+                                  bvNode.getOperand(0));
+  }
+
+  bool isBroadcast = true;
+  for (unsigned i = first_def + 1; i < bvNode.getNumOperands(); ++i) {
+    if (bvNode.getOperand(first_def) != bvNode.getOperand(i) && !bvNode.getOperand(i).isUndef()) {
+      isBroadcast = false;
+      break;
+    }
+  }
+
+  if (isBroadcast) {
+    return DAG.getNode(VEISD::VEC_BROADCAST, DL, Chain.getSimpleValueType(),
+                                  bvNode.getOperand(first_def));
+  }
+
+
+// match VEC_SEQ(stride) patterns
+  // identify a constant stride vector
+  bool hasConstantStride = true;
+
+  // whether the constant is a repetition of ascending indices, eg <0, 1, 2, 3, 0, 1, 2, 3, ..>
+  bool hasBlockStride = false;
+
+  // whether the constant is an ascending sequence of repeated indices, eg <0, 0, 1, 1, 2, 2, 3, 3 ..>
+  bool hasBlockStride2 = false;
+
+  bool firstStride = true;
+  int64_t blockLength = 0;
+  int64_t stride = 0;
+  int64_t lastElemValue = 0;
+  MVT elemTy;
+
+  for (unsigned i = 0; i < bvNode.getNumOperands(); ++i) {
+    if (hasBlockStride) {
+      if (i % blockLength == 0)
+        stride = 1;
+      else
+        stride = 0;
+    }
+
+    if (bvNode.getOperand(i).isUndef()) {
+      if (hasBlockStride2 && i % blockLength == 0)
+        lastElemValue = 0;
+      else
+        lastElemValue += stride;
+      continue;
+    }
+
+    // is this an immediate constant value?
+    auto * constNumElem = dyn_cast<ConstantSDNode>(bvNode.getOperand(i));
+    if (!constNumElem) {
+      hasConstantStride = false;
+      hasBlockStride = false;
+      hasBlockStride2 = false;
+      break;
+    }
+
+    // read value
+    int64_t elemValue = constNumElem->getSExtValue();
+    elemTy = constNumElem->getSimpleValueType(0);
+
+    if (i > first_def && firstStride) {
+      // first stride
+      stride = (elemValue - lastElemValue) / (i - first_def);
+      firstStride = false;
+    } else if (i > first_def) {
+      // later stride
+      if (hasBlockStride2 && elemValue == 0 && i % blockLength == 0) {
+        lastElemValue = 0;
+        continue;
+      }
+      int64_t thisStride = elemValue - lastElemValue;
+      if (thisStride != stride) {
+        hasConstantStride = false;
+        if (!hasBlockStride && thisStride == 1 && stride == 0 && lastElemValue == 0) {
+          hasBlockStride = true;
+          blockLength = i;
+        } else if (!hasBlockStride2 && elemValue == 0 && lastElemValue + 1 == i) {
+          hasBlockStride2 = true;
+          blockLength = i;
+        } else {
+          break;
+        }
+      }
+    }
+
+    // track last elem value
+    lastElemValue = elemValue;
+  }
+
+  // detected a proper stride pattern
+  if (hasConstantStride) {
+    SDValue seq = DAG.getNode(VEISD::VEC_SEQ, DL, Chain.getSimpleValueType(),
+                                  DAG.getConstant(1, DL, elemTy)); // TODO draw strideTy from elements
+    if (stride == 1)
+      return seq;
+
+    SDValue const_stride = DAG.getNode(VEISD::VEC_BROADCAST, DL, Chain.getSimpleValueType(), DAG.getConstant(stride, DL, elemTy));
+    return DAG.getNode(ISD::MUL, DL, Chain.getSimpleValueType(), {seq, const_stride});
+  }
+
+  // codegen for <0, 0, .., 0, 0, 1, 1, .., 1, 1, .....> constant patterns
+  // constant == VSEQ >> log2(blockLength)
+  if (hasBlockStride) {
+    int64_t blockLengthLog = log2(blockLength);
+
+    if (pow(2, blockLengthLog) == blockLength) {
+      SDValue sequence = DAG.getNode(VEISD::VEC_SEQ, DL, Chain.getSimpleValueType(), DAG.getConstant(1, DL, elemTy));
+      SDValue shiftbroadcast = DAG.getNode(VEISD::VEC_BROADCAST, DL, EVT::getVectorVT(*DAG.getContext(), EVT::getIntegerVT(*DAG.getContext(), 64), 256), DAG.getConstant(blockLengthLog, DL, EVT::getIntegerVT(*DAG.getContext(), 64)));
+
+      SDValue shift = DAG.getNode(ISD::SRL, DL, Chain.getSimpleValueType(), {sequence, shiftbroadcast});
+      return shift;
+    }
+  }
+
+  // codegen for <0, 1, .., 15, 0, 1, .., ..... > constant patterns
+  // constant == VSEQ % blockLength
+  if (hasBlockStride2) {
+    int64_t blockLengthLog = log2(blockLength);
+
+    if (pow(2, blockLengthLog) == blockLength) {
+      SDValue sequence = DAG.getNode(VEISD::VEC_SEQ, DL, Chain.getSimpleValueType(), DAG.getConstant(1, DL, elemTy));
+      SDValue modulobroadcast = DAG.getNode(VEISD::VEC_BROADCAST, DL, EVT::getVectorVT(*DAG.getContext(), EVT::getIntegerVT(*DAG.getContext(), 64), 256), DAG.getConstant(blockLength - 1, DL, EVT::getIntegerVT(*DAG.getContext(), 64)));
+
+      SDValue modulo = DAG.getNode(ISD::AND, DL, Chain.getSimpleValueType(), {sequence, modulobroadcast});
+
+      return modulo;
+    }
+  }
+
+  // default to element-wise insertion
+  SDValue newVector = DAG.getNode(VEISD::VEC_BROADCAST, DL, Chain.getSimpleValueType(),
+                                  bvNode.getOperand(0));
+
+  for (unsigned i = 0; i < bvNode.getNumOperands(); ++i) {
+    newVector = DAG.getNode(ISD::INSERT_VECTOR_ELT, DL, Chain.getSimpleValueType(),
+        newVector,
+        bvNode.getOperand(i),
+        DAG.getConstant(i, DL, EVT::getIntegerVT(*DAG.getContext(), 64))
+    );
+  }
+
+  return newVector;
+}
+
+SDValue
 VETargetLowering::LowerReturn(SDValue Chain, CallingConv::ID CallConv,
                               bool IsVarArg,
                               const SmallVectorImpl<ISD::OutputArg> &Outs,
@@ -1942,7 +2249,7 @@ SDValue VETargetLowering::LowerINTRINSIC_WO_CHAIN(SDValue Op,
       MVT BitcastVT = MVT::getVectorVT(
         MVT::i1, Mask.getValueType().getSizeInBits());
       SDValue Bitcast = DAG.getBitcast(BitcastVT, Mask);
-      return DAG.getNode(IntrData->Opc0, dl, Op.getValueType(), 
+      return DAG.getNode(IntrData->Opc0, dl, Op.getValueType(),
                          Op.getOperand(1), Bitcast, Op.getOperand(3));
     }
     case OP_XXXM: {
@@ -1952,7 +2259,7 @@ SDValue VETargetLowering::LowerINTRINSIC_WO_CHAIN(SDValue Op,
       //                  (v256f64 %v1), (v256f64 %v2),
       //                  (v4i64 %vm)))
       //   Output:
-      //     (v256f64 (VADDlvm %v1, %v2, 
+      //     (v256f64 (VADDlvm %v1, %v2,
       //                  (v256i1 (bitcast %vm))))
       SDValue Mask = Op.getOperand(3);
       MVT BitcastVT = MVT::getVectorVT(
@@ -1969,7 +2276,7 @@ SDValue VETargetLowering::LowerINTRINSIC_WO_CHAIN(SDValue Op,
       //                  (v256f64 %v1), (v256f64 %v2),
       //                  (v4i64 %vm), (v256f64 %vd)))
       //   Output:
-      //     (v256f64 (VADDlvm %v1, %v2, 
+      //     (v256f64 (VADDlvm %v1, %v2,
       //                  (v256i1 (bitcast %vm)), %vd))
       SDValue Mask = Op.getOperand(3);
       MVT BitcastVT = MVT::getVectorVT(
@@ -2310,6 +2617,134 @@ SDValue VETargetLowering::LowerINSERT_VECTOR_ELT(SDValue Op,
   return SDValue();
 }
 
+SDValue VETargetLowering::LowerSHUFFLE_VECTOR(SDValue Op, SelectionDAG &DAG) const {
+  LLVM_DEBUG(dbgs() << "Lowering Shuffle\n");
+  SDLoc dl(Op);
+  ShuffleVectorSDNode *ShuffleInstr = cast<ShuffleVectorSDNode>(Op.getNode());
+
+  SDValue firstVec = ShuffleInstr->getOperand(0);
+  int firstVecLength = firstVec.getSimpleValueType().getVectorNumElements();
+  SDValue secondVec = ShuffleInstr->getOperand(1);
+  int secondVecLength = secondVec.getSimpleValueType().getVectorNumElements();
+
+  MVT ElementType = Op.getSimpleValueType().getScalarType();
+  int resultSize = Op.getSimpleValueType().getVectorNumElements();
+
+  if (ShuffleInstr->isSplat()) {
+    int index = ShuffleInstr->getSplatIndex();
+    if (index >= firstVecLength) {
+      index -= firstVecLength;
+      SDValue elem = DAG.getNode(ISD::EXTRACT_VECTOR_ELT, dl, ElementType, {secondVec, DAG.getConstant(index, dl, EVT::getIntegerVT(*DAG.getContext(), 64))});
+      return DAG.getNode(VEISD::VEC_BROADCAST, dl, Op.getSimpleValueType(), elem);
+    } else {
+      SDValue elem = DAG.getNode(ISD::EXTRACT_VECTOR_ELT, dl, ElementType, {firstVec, DAG.getConstant(index, dl, EVT::getIntegerVT(*DAG.getContext(), 64))});
+      return DAG.getNode(VEISD::VEC_BROADCAST, dl, Op.getSimpleValueType(), elem);
+    }
+  }
+
+  if (firstVecLength != 256 || secondVecLength != 256 || resultSize != 256) {
+    LLVM_DEBUG(dbgs() << "Invalid vector lengths\n");
+    return SDValue();
+  }
+
+  int firstrot = 256;
+  int secondrot = 256;
+  int firstsecond = 256;
+  bool inv_order;
+
+  if (ShuffleInstr->getMaskElt(0) < 256) {
+    inv_order = false;
+  } else {
+    inv_order = true;
+  }
+
+  for (int i = 0; i < 256; i++) {
+    int mask_value = ShuffleInstr->getMaskElt(i);
+
+    if (mask_value < 0) // Undef
+      continue;
+
+    if (mask_value < 256) {
+      if (firstsecond != 256 && !inv_order) {
+        LLVM_DEBUG(dbgs() << "Mixing\n");
+        return SDValue();
+      }
+
+      if (firstsecond == 256 && inv_order)
+        firstsecond = i;
+
+      if (firstrot == 256)
+        firstrot = i - mask_value;
+      else if (firstrot != i - mask_value) {
+        LLVM_DEBUG(dbgs() << "Bad first rot\n");
+        return SDValue();
+      }
+    } else { //mask_value >= 256
+      if (firstsecond != 256 && inv_order) {
+        LLVM_DEBUG(dbgs() << "Mixing\n");
+        return SDValue();
+      }
+
+      if (firstsecond == 256 && !inv_order)
+        firstsecond = i;
+
+      mask_value -= 256;
+
+      if (secondrot == 256)
+        secondrot = i - mask_value;
+      else if (secondrot != i - mask_value) {
+        LLVM_DEBUG(dbgs() << "Bad second rot\n");
+        return SDValue();
+      }
+    }
+  }
+
+  if (firstrot < 0)
+    firstrot *= -1;
+  else
+    firstrot = 256 - firstrot;
+  if (secondrot < 0)
+    secondrot *= -1;
+  else
+    secondrot = 256 - secondrot;
+
+  SDValue firstrotated = firstrot % 256 != 0 ? DAG.getNode(VEISD::VEC_VMV, dl, firstVec.getSimpleValueType(), {DAG.getConstant(firstrot % 256, dl, EVT::getIntegerVT(*DAG.getContext(), 32)), firstVec}) : firstVec;
+  SDValue secondrotated = secondrot % 256 != 0 ? DAG.getNode(VEISD::VEC_VMV, dl, secondVec.getSimpleValueType(), {DAG.getConstant(secondrot % 256, dl, EVT::getIntegerVT(*DAG.getContext(), 32)), secondVec}) : secondVec;
+
+  EVT i64 = EVT::getIntegerVT(*DAG.getContext(), 64);
+  EVT v256i1 = EVT::getVectorVT(*DAG.getContext(), EVT::getIntegerVT(*DAG.getContext(), 1), 256);
+
+  //TODO: use LVM and SVM instructions!
+  int block = firstsecond / 64;
+  int secondblock = firstsecond % 64;
+
+  SDValue Mask = DAG.getUNDEF(v256i1);
+
+  for (int i = 0; i < block; i++) {
+    //set blocks to all 0s
+    SDValue mask = inv_order ? DAG.getConstant(0xffffffffffffffff, dl, i64) : DAG.getConstant(0, dl, i64);
+    SDValue index = DAG.getConstant(i, dl, i64);
+    Mask = DAG.getNode(VEISD::INT_LVM, dl, v256i1, {Mask, index, mask});
+  }
+
+  SDValue mask = DAG.getConstant(0xffffffffffffffff, dl, i64);
+  if (!inv_order)
+    mask = DAG.getNode(ISD::SRL, dl, i64, {mask, DAG.getConstant(secondblock, dl, i64)});
+  else
+    mask = DAG.getNode(ISD::SHL, dl, i64, {mask, DAG.getConstant(64 - secondblock, dl, i64)});
+  Mask = DAG.getNode(VEISD::INT_LVM, dl, v256i1, {Mask, DAG.getConstant(block, dl, i64), mask});
+
+  for (int i = block + 1; i < 4; i++) {
+    //set blocks to all 1s
+    SDValue mask = inv_order ? DAG.getConstant(0, dl, i64) : DAG.getConstant(0xffffffffffffffff, dl, i64);
+    SDValue index = DAG.getConstant(i, dl, i64);
+    Mask = DAG.getNode(VEISD::INT_LVM, dl, v256i1, {Mask, index, mask});
+  }
+
+  SDValue returnValue = DAG.getNode(VEISD::INT_VMRG, dl, Op.getSimpleValueType(), {firstrotated, secondrotated, Mask});
+  return returnValue;
+}
+
 SDValue VETargetLowering::LowerEXTRACT_VECTOR_ELT(SDValue Op,
                                                   SelectionDAG &DAG) const {
   assert(Op.getOpcode() == ISD::EXTRACT_VECTOR_ELT && "Unknown opcode!");
@@ -2623,7 +3058,7 @@ VETargetLowering::EmitSjLjDispatchBlock(MachineInstr &MI,
     BuildMI(DispContBB, DL, TII->get(VE::SLLri), Tmp1)
         .addReg(IReg)
         .addImm(3);
-    // FIXME: combine these add and lds into "lds     TReg, *(BReg, Tmp1)" 
+    // FIXME: combine these add and lds into "lds     TReg, *(BReg, Tmp1)"
     // adds.l  Tmp2, BReg, Tmp1
     BuildMI(DispContBB, DL, TII->get(VE::ADXrr), Tmp2)
         .addReg(Tmp1)
@@ -2655,7 +3090,7 @@ VETargetLowering::EmitSjLjDispatchBlock(MachineInstr &MI,
     BuildMI(DispContBB, DL, TII->get(VE::SLLri), Tmp1)
         .addReg(IReg)
         .addImm(2);
-    // FIXME: combine these add and ldl into "ldl     OReg, *(BReg, Tmp1)" 
+    // FIXME: combine these add and ldl into "ldl     OReg, *(BReg, Tmp1)"
     // add     Tmp2, BReg, Tmp1
     BuildMI(DispContBB, DL, TII->get(VE::ADXrr), Tmp2)
         .addReg(Tmp1)
@@ -2689,7 +3124,7 @@ VETargetLowering::EmitSjLjDispatchBlock(MachineInstr &MI,
     BuildMI(DispContBB, DL, TII->get(VE::SLLri), Tmp1)
         .addReg(IReg)
         .addImm(2);
-    // FIXME: combine these add and ldl into "ldl.zx   OReg, *(BReg, Tmp1)" 
+    // FIXME: combine these add and ldl into "ldl.zx   OReg, *(BReg, Tmp1)"
     // add     Tmp2, BReg, Tmp1
     BuildMI(DispContBB, DL, TII->get(VE::ADXrr), Tmp2)
         .addReg(Tmp1)

--- a/lib/Target/VE/VEISelLowering.cpp
+++ b/lib/Target/VE/VEISelLowering.cpp
@@ -1289,6 +1289,12 @@ const char *VETargetLowering::getTargetNodeName(unsigned Opcode) const {
   case VEISD::RET_FLAG:        return "VEISD::RET_FLAG";
   case VEISD::GLOBAL_BASE_REG: return "VEISD::GLOBAL_BASE_REG";
   case VEISD::FLUSHW:          return "VEISD::FLUSHW";
+  case VEISD::VEC_BROADCAST:   return "VEISD::VEC_BROADCAST";
+  case VEISD::VEC_LVL:         return "VEISD::VEC_LVL";
+  case VEISD::VEC_SEQ:         return "VEISD::VEC_SEQ";
+  case VEISD::VEC_VMV:         return "VEISD::VEC_VMV";
+  case VEISD::VEC_SCATTER:     return "VEISD::VEC_SCATTER";
+  case VEISD::VEC_GATHER:      return "VEISD::VEC_GATHER";
   case VEISD::Wrapper:         return "VEISD::Wrapper";
   case VEISD::INT_LVM:         return "VEISD::INT_LVM";
   case VEISD::INT_SVM:         return "VEISD::INT_SVM";

--- a/lib/Target/VE/VEISelLowering.h
+++ b/lib/Target/VE/VEISelLowering.h
@@ -230,7 +230,7 @@ namespace llvm {
   public:
     VETargetLowering(const TargetMachine &TM, const VESubtarget &STI);
     SDValue LowerOperation(SDValue Op, SelectionDAG &DAG) const override;
-    
+
     /// computeKnownBitsForTargetNode - Determine which of the bits specified
     /// in Mask are known to be either zero or one and return them in the
     /// KnownZero/KnownOne bitsets.
@@ -323,6 +323,15 @@ namespace llvm {
     SDValue LowerToTLSLocalExecModel(SDValue Op, SelectionDAG &DAG) const;
     SDValue LowerConstantPool(SDValue Op, SelectionDAG &DAG) const;
     SDValue LowerBlockAddress(SDValue Op, SelectionDAG &DAG) const;
+    SDValue LowerBUILD_VECTOR(SDValue Op, SelectionDAG &DAG) const;
+
+    SDValue LowerBitcast(SDValue Op, SelectionDAG &DAG) const;
+
+    SDValue LowerSHUFFLE_VECTOR(SDValue Op, SelectionDAG &DAG) const;
+
+    SDValue LowerMGATHER_MSCATTER(SDValue Op, SelectionDAG &DAG) const;
+
+    SDValue LowerMLOAD(SDValue Op, SelectionDAG &DAG) const;
 
     SDValue LowerEH_SJLJ_SETJMP(SDValue Op, SelectionDAG &DAG) const;
     SDValue LowerEH_SJLJ_LONGJMP(SDValue Op, SelectionDAG &DAG) const;

--- a/lib/Target/VE/VEISelLowering.h
+++ b/lib/Target/VE/VEISelLowering.h
@@ -62,6 +62,17 @@ namespace llvm {
       GLOBAL_BASE_REG, // Global base reg for PIC.
       FLUSHW,      // FLUSH register windows to stack.
 
+      VEC_BROADCAST,   // a scalar value is broadcast across all vector lanes (Operand 0: the broadcast register)
+      VEC_SEQ,         // sequence vector match (Operand 0: the constant stride)
+
+      VEC_VMV,
+
+      /// Scatter and gather instructions.
+      VEC_GATHER,
+      VEC_SCATTER,
+
+      VEC_LVL,
+
       /// A wrapper node for TargetConstantPool, TargetJumpTable,
       /// TargetExternalSymbol, TargetGlobalAddress, TargetGlobalTLSAddress,
       /// MCSymbol and TargetBlockAddress.

--- a/lib/Target/VE/VEISelLowering.h
+++ b/lib/Target/VE/VEISelLowering.h
@@ -368,7 +368,6 @@ namespace llvm {
     bool shouldExpandBuildVectorWithShuffles(EVT VT,
         unsigned DefinedValues) const override;
 
-    SDValue LowerBUILD_VECTOR(SDValue Op, SelectionDAG &DAG) const;
     SDValue LowerEXTRACT_VECTOR_ELT(SDValue Op, SelectionDAG &DAG) const;
     SDValue LowerINSERT_VECTOR_ELT(SDValue Op, SelectionDAG &DAG) const;
 
@@ -410,6 +409,9 @@ namespace llvm {
                                              MachineBasicBlock *BB) const;
     void SetupEntryBlockForSjLj(MachineInstr &MI, MachineBasicBlock *MBB,
                                 MachineBasicBlock *DispatchBB, int FI) const;
+
+  private:
+    bool isFMAFasterThanFMulAndFAdd(EVT VT) const override { return true; }
   };
 } // end namespace llvm
 

--- a/lib/Target/VE/VEInstrPatternsVec.td
+++ b/lib/Target/VE/VEInstrPatternsVec.td
@@ -171,7 +171,7 @@ def: Pat<(f32 (extractelt v256f32:$vec, i64:$idx)),
 
 def: Pat<(f64 (extractelt v256f64:$vec, uimm7:$idx)),
          (LVSi v256f64:$vec, imm:$idx)>;
-def: Pat<(f64 (extractelt v256f64:$vec, f64:$idx)),
+def: Pat<(f64 (extractelt v256f64:$vec, i64:$idx)),
          (LVSr v256f64:$vec, $idx)>;
 
 def: Pat<(i64 (extractelt v256i64:$vec, uimm7:$idx)),

--- a/lib/Target/VE/VEInstrPatternsVec.td
+++ b/lib/Target/VE/VEInstrPatternsVec.td
@@ -179,3 +179,152 @@ def: Pat<(i64 (extractelt v256i64:$vec, uimm7:$idx)),
 def: Pat<(i64 (extractelt v256i64:$vec, i64:$idx)),
          (LVSr v256i64:$vec, $idx)>;
 
+// Custom ISDs
+// VEISD::VEC_SEQ - represents a vector sequence where the operand is the stride
+// VEISD::VEC_BROADCAST - represents a vector splat of a scalar value into all vector lanes.
+
+def vec_seq         : SDNode<"VEISD::VEC_SEQ",       SDTypeProfile<1, 1, [SDTCisVec<0>, SDTCisInt<1>]>>;
+def vec_broadcast   : SDNode<"VEISD::VEC_BROADCAST", SDTypeProfile<1, 1, [SDTCisVec<0>]>>;
+
+def vec_scatter   : SDNode<"VEISD::VEC_SCATTER", SDTypeProfile<0, 2, [SDTCisVec<0>, SDTCisVec<1>]>, [SDNPHasChain, SDNPMayStore, SDNPMemOperand]>;
+def vec_gather   : SDNode<"VEISD::VEC_GATHER", SDTypeProfile<1, 1, [SDTCisVec<0>, SDTCisVec<1>]>, [SDNPHasChain, SDNPMayLoad, SDNPMemOperand]>;
+
+def vec_lvl   : SDNode<"VEISD::VEC_LVL", SDTypeProfile<0, 1, []>, [SDNPHasChain]>;
+
+def vec_rotate   : SDNode<"VEISD::VEC_VMV", SDTypeProfile<1, 2, []>>;
+def : Pat<(v256f64 (vec_rotate i32:$sy, v256f64:$vz)), (VMVr i32:$sy, v256f64:$vz)>;
+def : Pat<(v256f64 (vec_rotate (i32 simm7:$I), v256f64:$vz)), (VMVi (i32 simm7:$I), v256f64:$vz)>;
+
+// Shuffle
+// TODO
+
+// Scatter
+def : Pat<(vec_scatter v256i64:$vx, v256i64:$vy), (VSCv v256i64:$vx, v256i64:$vy)>;
+def : Pat<(vec_scatter v256f64:$vx, v256i64:$vy), (VSCv v256f64:$vx, v256i64:$vy)>;
+
+// Gather
+def : Pat<(v256i64 (vec_gather v256i64:$vy)), (VGTv v256i64:$vy)>;
+def : Pat<(v256f64 (vec_gather v256i64:$vy)), (VGTv v256i64:$vy)>;
+
+// LVL
+def : Pat<(vec_lvl i32:$sy), (LVL i32:$sy)>;
+
+// Broadcast
+def : Pat<(v256f64 (scalar_to_vector f64:$sy)), (VBRDf64r f64:$sy)>;
+
+def : Pat<(v256i64 (vec_broadcast i64:$sy)), (VBRDr i64:$sy)>;
+def : Pat<(v256f64 (vec_broadcast f64:$sy)), (VBRDf64r f64:$sy)>;
+def : Pat<(v256i32 (vec_broadcast i32:$sy)), (VBRDi32r i32:$sy)>; 
+def : Pat<(v256f32 (vec_broadcast f32:$sy)), (VBRDf32r f32:$sy)>;
+// def : Pat<(v512f32 (vec_broadcast f32:$sy)), (VBRDpr f32:$sy)>; 
+def : Pat<(v512i32 (vec_broadcast i64:$sy)), (VBRDpr i64:$sy)>; 
+
+// Condition Code
+def : Pat<(setcc v256i64:$vx, v256i64:$vy, CCSIOp:$cond),
+          (v256i1 (VFMKv (icond2cc $cond), (VCMPlv v256i64:$vx, v256i64:$vy)))>;
+
+def : Pat<(setcc v256f64:$vx, v256f64:$vy, CCSIOp:$cond),
+          (v256i1 (VFMKv (fcond2cc $cond), (VCMPwv v256f64:$vx, v256f64:$vy)))>;
+
+// (VFMKv (i32 uimm6:$cc), v256f64:$vz)
+
+// def : Pat<(i32 (setcc i64:$LHS, i64:$RHS, CCSIOp:$cond)),
+//           (EXTRACT_SUBREG
+//               (CMOVLrm0 )>;
+// 
+// def : Pat<(setcc v256i64:$vx, v256i64:$vy, $cc),
+//           (VFMKv (i32 uimm6:( $cc)), v256f64:$vz)>;
+
+// Vector Select
+
+def : Pat<(v256f64 (vselect v256i1:$m, v256f64:$vy, v256f64:$vz)), 
+          (v256f64 (VMRGvm v256f64:$vz, v256f64:$vy, v256i1:$m))>; 
+def : Pat<(v512f32 (vselect v512i1:$m, v512f32:$vy, v512f32:$vz)),
+          (VMRGpvm v512f32:$vz, v512f32:$vy, v512i1:$m)>;
+
+// Sequence
+
+def : Pat<(v256i32 (vec_seq (i32 1))), (VSEQlv)>;
+def : Pat<(v512i32 (vec_seq (i32 1))), (VSEQpv)>;
+def : Pat<(v256i64 (vec_seq (i64 1))), (VSEQv)>;
+
+// Format Conversions
+
+// sint -> floating-point
+
+def : Pat<(v256f64 (sint_to_fp v256i64:$vx)), (VFLTXv $vx)>;
+def : Pat<(v256f64 (sint_to_fp v256i32:$vx)), (VFLTdv $vx)>;
+def : Pat<(v256f32 (sint_to_fp v256i32:$vx)), (VFLTsv $vx)>;
+def : Pat<(v512f32 (sint_to_fp v512i32:$vx)), (VFLTpv $vx)>;
+
+// Double-Precision Arithmetic
+
+def : Pat<(fadd (v256f64 (vec_broadcast f64:$sy)), v256f64:$vz), (VFADdr f64:$sy, v256f64:$vz)>; 
+def : Pat<(fadd v256f64:$vy, v256f64:$vz), (VFADdv v256f64:$vy, v256f64:$vz)>;
+
+def : Pat<(fsub (v256f64 (vec_broadcast f64:$sy)), v256f64:$vz), (VFSBdr f64:$sy, v256f64:$vz)>; 
+def : Pat<(fsub v256f64:$vy, v256f64:$vz), (VFSBdv v256f64:$vy, v256f64:$vz)>;
+
+def : Pat<(fmul (v256f64 (vec_broadcast f64:$sy)), v256f64:$vz), (VFMPdr f64:$sy, v256f64:$vz)>; 
+def : Pat<(fmul v256f64:$vy, v256f64:$vz), (VFMPdv v256f64:$vy, v256f64:$vz)>;
+
+def : Pat<(fdiv (v256f64 (vec_broadcast f64:$sy)), v256f64:$vz), (VFDVdr f64:$sy, v256f64:$vz)>; 
+def : Pat<(fdiv v256f64:$vy, v256f64:$vz), (VFDVdv v256f64:$vy, v256f64:$vz)>;
+
+def : Pat<(fma v256f64:$vz, v256f64:$vw, (v256f64 (fneg v256f64:$vy))), (VFMSBdv v256f64:$vy, v256f64:$vz, v256f64:$vw)>;
+
+def : Pat<(fma (v256f64 (vec_broadcast f64:$sy)), v256f64:$vw, v256f64:$vy), (VFMADdr2 v256f64:$vy, f64:$sy, v256f64:$vw)>;
+def : Pat<(fma v256f64:$vw, (v256f64 (vec_broadcast f64:$sy)), v256f64:$vy), (VFMADdr2 v256f64:$vy, f64:$sy, v256f64:$vw)>;
+def : Pat<(fma v256f64:$vz, v256f64:$vw, (v256f64 (vec_broadcast f64:$sy))), (VFMADdr f64:$sy, v256f64:$vz, v256f64:$vw)>;
+def : Pat<(fma v256f64:$vz, v256f64:$vw, v256f64:$vy), (VFMADdv v256f64:$vy, v256f64:$vz, v256f64:$vw)>;
+
+def : Pat<(fneg v256f64:$vz), (VFSBdr (i64 0), v256f64:$vz)>;
+
+// Packed Single-Precision Arithmetic
+
+def : Pat<(fadd (vec_broadcast i64:$sy), v512f32:$vz), (VFADpr i64:$sy, v512f32:$vz)>;
+def : Pat<(fadd v512f32:$vy, v512f32:$vz), (VFADpv v512f32:$vy, v512f32:$vz)>;
+
+def : Pat<(fsub (vec_broadcast i64:$sy), v512f32:$vz), (VFSBpr i64:$sy, v512f32:$vz)>;
+def : Pat<(fsub v512f32:$vy, v512f32:$vz), (VFSBpv v512f32:$vy, v512f32:$vz)>;
+
+def : Pat<(fmul (vec_broadcast i64:$sy), v512f32:$vz), (VFMPpr i64:$sy, v512f32:$vz)>;
+def : Pat<(fmul v512f32:$vy, v512f32:$vz), (VFMPpv v512f32:$vy, v512f32:$vz)>;
+
+def : Pat<(fdiv (v512f32 (vec_broadcast i64:$sy)), v512f32:$vz), (VFDVpr i64:$sy, v512f32:$vz)>; 
+def : Pat<(fdiv v512f32:$vy, v512f32:$vz), (VFDVpv v512f32:$vy, v512f32:$vz)>;
+
+def : Pat<(fma v512f32:$vz, v512f32:$vw, (v512f32 (fneg v512f32:$vy))), (VFMSBpv v512f32:$vy, v512f32:$vz, v512f32:$vw)>;
+
+def : Pat<(fma (v256f32 (vec_broadcast i64:$sy)), v256f32:$vw, v256f32:$vy), (VFMADpr2 v256f32:$vy, i64:$sy, v256f32:$vw)>;
+def : Pat<(fma v256f32:$vw, (v256f32 (vec_broadcast i64:$sy)), v256f32:$vy), (VFMADpr2 v256f32:$vy, i64:$sy, v256f32:$vw)>;
+def : Pat<(fma v256f32:$vz, v256f32:$vw, (v256f32 (vec_broadcast i64:$sy))), (VFMADpr i64:$sy, v256f32:$vz, v256f32:$vw)>;
+def : Pat<(fma v256f32:$vz, v256f32:$vw, v256f32:$vy), (VFMADpv v256f32:$vy, v256f32:$vz, v256f32:$vw)>;
+
+def : Pat<(fneg v512f32:$vz), (VFSBpr (i64 0), v512f32:$vz)>;
+
+// Integer Arithmetic
+
+def : Pat<(add v512i32:$vx, v512i32:$vy), (VADDpv v512i32:$vx, v512i32:$vy)>;
+def : Pat<(add v256i32:$vx, v256i32:$vy), (VADDlv v256i32:$vx, v256i32:$vy)>;
+def : Pat<(add v256i64:$vx, v256i64:$vy), (VADXlv v256i64:$vx, v256i64:$vy)>;
+
+def : Pat<(add v512i32:$vx, v512i32:$vy), (VADDpv v512i32:$vx, v512i32:$vy)>;
+def : Pat<(add v256i32:$vx, v256i32:$vy), (VADDlv v256i32:$vx, v256i32:$vy)>;
+def : Pat<(add v256i64:$vx, v256i64:$vy), (VADXlv v256i64:$vx, v256i64:$vy)>;
+
+def : Pat<(add v512i32:$vx, v512i32:$vy), (VADDpv v512i32:$vx, v512i32:$vy)>;
+def : Pat<(add v256i32:$vx, v256i32:$vy), (VADDlv v256i32:$vx, v256i32:$vy)>;
+def : Pat<(add v256i64:$vx, v256i64:$vy), (VADXlv v256i64:$vx, v256i64:$vy)>;
+
+// Logic
+def : Pat<(and v256i64:$vx, v256i64:$vy), (VANDv v256i64:$vx, v256i64:$vy)>;
+def : Pat<(or  v256i64:$vx, v256i64:$vy), (VORv v256i64:$vx, v256i64:$vy)>;
+def : Pat<(xor v256i64:$vx, v256i64:$vy), (VXORv v256i64:$vx, v256i64:$vy)>;
+
+// Shifts
+def : Pat<(shl v256i64:$vx, (v256i64 (vec_broadcast i64:$sy))), (VSLAXr2 v256i64:$vx, i64:$sy)>;
+def : Pat<(srl v256i64:$vx, (v256i64 (vec_broadcast i64:$sy))), (VSRLr2 v256i64:$vx, i64:$sy)>;
+
+def : Pat<(shl v256i64:$vx, v256i64:$vy), (VSLAXv v256i64:$vx, v256i64:$vy)>;
+def : Pat<(srl v256i64:$vx, v256i64:$vy), (VSRLv v256i64:$vx, v256i64:$vy)>;

--- a/lib/Target/VE/VETargetTransformInfo.h
+++ b/lib/Target/VE/VETargetTransformInfo.h
@@ -60,6 +60,24 @@ public:
 
   unsigned getMinVectorRegisterBitWidth() const { return 256*64; }
 
+  bool isLegalMaskedLoad(Type *DataType) {
+    return true;
+  }
+
+  bool isLegalMaskedGather(Type *DataType) {
+      //if (DataType->getVectorNumElements() != 256) {
+      //  return false;
+      //}
+      return true;
+  };
+
+  bool isLegalMaskedScatter(Type *DataType) {
+      //if (DataType->getVectorNumElements() != 256) {
+      //  return false;
+      //}
+      return true;
+  };
+
 };
 
 }


### PR DESCRIPTION
### new SDNodes
* VEC_SEQ(c) - `<1*c, 2*c, 3*c, ..>`
* VEC_BROADCAST(c) - `<c, c, c, c, ..>`
* VEC_VMV(v, s) - `<v_s, v_{s+1}, ..>`
* VEC_LVL - load vector length.

### custom lowerings
* BUILD_VECTOR - custom lowering for constants, some VSEQ patterns and broadcasts.
* SHUFFLE_VECTOR - VMV matching
* GATHER/SCATTER/MLOAD/MSTORE - initial support for all-true masks

### patterns
* vector fp arithmetic
* vector int arithmetic